### PR TITLE
Remove link to FCC comment form

### DIFF
--- a/src/resources/message.txt
+++ b/src/resources/message.txt
@@ -15,8 +15,6 @@ Jessica Rosenworcel|Jessica.Rosenworcel@fcc.gov|[@JRosenworcel](https://twitter.
 
 Write to your [House Representative here](http://www.house.gov/representatives/find/) and [Senators here](https://www.senate.gov/general/contact_information/senators_cfm.cfm?OrderBy=state)
 
-Add a comment to the repeal [here](https://www.fcc.gov/ecfs/search/filings?proceedings_name=17-108&amp;sort=date_disseminated,DESC) (and [here's](http://www.gofccyourself.com) an easier URL you can use thanks to John Oliver)
-
 [You can also use this to help you contact your house and congressional reps.](https://resistbot.io/) It's easy to use and cuts down on the transaction costs with writing a letter to your reps
 
 [Whitehouse.gov petition here](https://petitions.whitehouse.gov/petition/do-not-repeal-net-neutrality)


### PR DESCRIPTION
The comment period has long been closed, directing people there is a waste of their time